### PR TITLE
bsread writer with a message buffer

### DIFF
--- a/mflow_processor/bsread_writer.py
+++ b/mflow_processor/bsread_writer.py
@@ -67,13 +67,13 @@ class BsreadWriter(BaseProcessor):
 
     @staticmethod
     def receive_messages(running_event, connect_address, output_file, receive_timeout, n_pulses, start_event):
+        _logger = getLogger("bsread_receive_message")
+        _logger.info("Writing channels to output_file '%s'.", output_file)
+        _logger.info("Connecting to stream '%s'.", connect_address)
+
+        h5_writer = None
+
         try:
-            _logger = getLogger("bsread_receive_message")
-            _logger.info("Writing channels to output_file '%s'.", output_file)
-            _logger.info("Connecting to stream '%s'.", connect_address)
-
-            h5_writer = None
-
             current_pulse = 0
 
             handler = extended.Handler()

--- a/mflow_processor/bsread_writer.py
+++ b/mflow_processor/bsread_writer.py
@@ -28,6 +28,8 @@ class BsreadWriter(BaseProcessor):
         channels                       Channels to request from the dispatching layer.
         output_file                    File to write the stream to.
         receive_timeout                Timeout to use when receiving data from the dispatching layer.
+        start_pulse_id                 Initial pulse_id to be saved in hdf5 file
+        end_pulse_id                   Last pulse_id to be saved in hdf5 file
     """
     _logger = getLogger(__name__)
 

--- a/mflow_processor/bsread_writer.py
+++ b/mflow_processor/bsread_writer.py
@@ -4,7 +4,7 @@ from collections import deque
 
 from mflow import mflow
 from bsread import dispatcher, writer, SUB
-from bsread.handlers import extended
+from bsread.handlers import compact
 from mflow_nodes.processors.base import BaseProcessor
 from mflow_processor.utils.h5_utils import create_folder_if_does_not_exist
 
@@ -76,7 +76,7 @@ class BsreadWriter(BaseProcessor):
         try:
             current_pulse = 0
 
-            handler = extended.Handler()
+            handler = compact.Handler()
             receiver = mflow.connect(connect_address, receive_timeout=receive_timeout, mode=SUB)
 
             running_event.set()

--- a/mflow_processor/bsread_writer.py
+++ b/mflow_processor/bsread_writer.py
@@ -62,8 +62,11 @@ class BsreadWriter(BaseProcessor):
         """
         error_message = ""
 
-        if not self.output_file and self.channels:
+        if not self.output_file:
             error_message += "Parameter 'output_file' not set.\n"
+
+        if not self.channels:
+            error_message += "No channels specified.\n"
 
         if error_message:
             self._logger.error(error_message)
@@ -143,10 +146,6 @@ class BsreadWriter(BaseProcessor):
         # Check if all the needed input parameters are available.
         self._validate_parameters()
         self._logger.debug("Starting mflow_processor.")
-
-        if not self.channels:
-            self._logger.info("No channels specified. Not writing anything.")
-            return
 
         self._logger.info("Requesting channels from dispatching layer: %s", self.channels)
         address = dispatcher.request_stream(self.channels)


### PR DESCRIPTION
This is a draft of the bsread writer with an intermediate buffer for mflow messages.
Currently, it saves only pulse_ids to the hdf5 file (primarily, for debugging purposes).